### PR TITLE
Implement support for go peers through parametric language implementations

### DIFF
--- a/cmd/dsl/commands.go
+++ b/cmd/dsl/commands.go
@@ -16,9 +16,7 @@ import (
 )
 
 func asyncRequest(p Puppet, method muxrpc.Method, payload, response interface{}) error {
-	secretFile := fmt.Sprintf(`/home/cblgh/code/netsim-experiments/ssb-server/puppet_%d/secret`, p.instanceID)
-
-	c, err := client.NewTCP(p.Port, secretFile)
+	c, err := client.NewTCP(p.Port, fmt.Sprintf("%s/secret", p.directory))
 	if err != nil {
 		return err
 	}
@@ -34,9 +32,7 @@ func asyncRequest(p Puppet, method muxrpc.Method, payload, response interface{})
 }
 
 func sourceRequest(p Puppet, method muxrpc.Method, opts interface{}) (muxrpc.Endpoint, *muxrpc.ByteSource, error) {
-	secretFile := fmt.Sprintf(`/home/cblgh/code/netsim-experiments/ssb-server/puppet_%d/secret`, p.instanceID)
-
-	c, err := client.NewTCP(p.Port, secretFile)
+	c, err := client.NewTCP(p.Port, fmt.Sprintf("%s/secret", p.directory))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/dsl/commands.go
+++ b/cmd/dsl/commands.go
@@ -22,7 +22,11 @@ func asyncRequest(p Puppet, method muxrpc.Method, payload, response interface{})
 	}
 
 	ctx := context.TODO()
-	err = c.Async(ctx, &response, muxrpc.TypeJSON, method, payload)
+	muxEncodingType := muxrpc.TypeJSON
+	if method[0] == "publish" {
+		muxEncodingType = muxrpc.TypeString
+	}
+	err = c.Async(ctx, response, muxEncodingType, method, payload)
 	if err != nil {
 		return err
 	}
@@ -185,7 +189,7 @@ func DoFollow(srcPuppet, dstPuppet Puppet, isFollow bool) error {
 	followContent := refs.NewContactFollow(feedRef)
 	followContent.Following = isFollow
 
-	var response interface{}
+	var response string
 	err = asyncRequest(srcPuppet, muxrpc.Method{"publish"}, followContent, &response)
 	return err
 }
@@ -193,7 +197,7 @@ func DoFollow(srcPuppet, dstPuppet Puppet, isFollow bool) error {
 func DoPost(p Puppet) error {
 	post := refs.NewPost("bep")
 
-	var response interface{}
+	var response string
 	return asyncRequest(p, muxrpc.Method{"publish"}, post, &response)
 }
 

--- a/cmd/dsl/commands.go
+++ b/cmd/dsl/commands.go
@@ -63,7 +63,7 @@ func DoDisconnect(src, dst Puppet) error {
 // TODO: use createLogStream opts here, as we use them in DoLog?
 func queryLatest(p Puppet) ([]Latest, error) {
 	var empty interface{}
-	c, src, err := sourceRequest(p, muxrpc.Method{"latest"}, empty)
+	c, src, err := sourceRequest(p, muxrpc.Method{"replicate", "upto"}, empty)
 	if err != nil {
 		return nil, err
 	}
@@ -242,8 +242,7 @@ func DoIsNotFollowing(srcPuppet, dstPuppet Puppet) error {
 		return err
 	}
 	if isFollowing {
-		srcID := srcPuppet.feedID
-		dstID := dstPuppet.feedID
+		srcID, dstID := srcPuppet.feedID, dstPuppet.feedID
 		m := fmt.Sprintf("%s should not follow %s\nactual: %s is following %s", srcID, dstID, srcID, dstID)
 		return TestError{err: errors.New("isfollowing returned true"), message: m}
 	}

--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -220,11 +220,9 @@ func main() {
 	flag.StringVar(&outdir, "out", "./puppets", "the output directory containing instantiated netsim peers")
 	flag.Parse()
 
-	if len(os.Args) > 1 {
-		fmt.Println("language implementations:")
-		for i, dir := range os.Args[1:] {
-			fmt.Println(i, dir)
-		}
+	fmt.Println("language implementations:")
+	for i, dir := range flag.Args() {
+		fmt.Println(i, dir)
 	}
 	/*
 	 * the language implementation dir contains the code for starting a puppet, via a shim.

--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -54,7 +53,7 @@ type Simulator struct {
 }
 
 func startPuppet(s Simulator, p Puppet, shim string) error {
-	filename := path.Join(s.puppetDir, fmt.Sprintf("%s.txt", p.name))
+	filename := filepath.Join(s.puppetDir, fmt.Sprintf("%s.txt", p.name))
 	logfile, err := os.Create(filename)
 	if err != nil {
 		return TestError{err: err, message: "could not create log file"}
@@ -64,7 +63,7 @@ func startPuppet(s Simulator, p Puppet, shim string) error {
 	// currently the simulator has a requirement that each language implementation folder must contain a sim-shim.sh file
 	// sim-shim.sh contains logic for starting the corresponding sbot correctly.
 	// e.g. reading the passed in ssb directory ($1) and port ($2)
-	cmd = exec.Command(path.Join(s.implementations[shim], "sim-shim.sh"), p.directory, strconv.Itoa(p.Port))
+	cmd = exec.Command(filepath.Join(s.implementations[shim], "sim-shim.sh"), p.directory, strconv.Itoa(p.Port))
 	cmd.Stderr = logfile
 	cmd.Stdout = logfile
 	err = cmd.Run()
@@ -151,7 +150,7 @@ func (s Simulator) execute() {
 				continue
 			}
 			subfolder := fmt.Sprintf("%s-%s", langImpl, name)
-			fullpath := path.Join(s.puppetDir, subfolder)
+			fullpath := filepath.Join(s.puppetDir, subfolder)
 			p := Puppet{name: name, directory: fullpath, Port: s.acquirePort()}
 			go startPuppet(s, p, langImpl)
 			time.Sleep(1 * time.Second)

--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -213,6 +213,27 @@ func (s Simulator) execute() {
 	fmt.Printf("1..%d\n", len(s.instructions))
 }
 
+func resetPuppetDir(dir string) {
+	if dir == "/" || dir == "~" || dir == "C:/" {
+		fmt.Println("you are trying to remove an important system folder, netsim will stop execution instead")
+		os.Exit(0)
+	}
+	absdir, err := filepath.Abs(dir)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	// remove the puppet dir and its subfolders
+	err = os.RemoveAll(absdir)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	// recreate it
+	err = os.Mkdir(absdir, 0777)
+	if err != nil {
+		log.Fatalln(err)
+	}
+}
+
 func main() {
 	var testfile string
 	flag.StringVar(&testfile, "spec", "./test.txt", "test file containing network simulator test instructions")
@@ -237,6 +258,7 @@ func main() {
 	 *   an output directory containing all puppet folders
 	 *   some way to instantiate seeded secrets for each puppet
 	 */
+	resetPuppetDir(outdir)
 	sim := makeSimulator(18888, outdir)
 	lines := readTest(testfile)
 	sim.ParseTest(lines)

--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -107,15 +107,21 @@ func (s *Simulator) incrementPort() {
 	s.portCounter += 1
 }
 
-func (s *Simulator) ParseTest(lines []string) {
+func (s *Simulator) ParseTest(lines []string, verbose bool) {
 	s.instructions = make([]Instruction, 0, len(lines))
-	fmt.Println("## Start test file")
+	if verbose {
+		fmt.Println("## Start test file")
+	}
 	for i, line := range lines {
 		instr := parseTestLine(line, i+1)
-		instr.Print()
+		if verbose {
+			instr.Print()
+		}
 		s.instructions = append(s.instructions, instr)
 	}
-	fmt.Println("## End test file")
+	if verbose {
+		fmt.Println("## End test file")
+	}
 }
 
 func (s Simulator) evaluateRun(err error) {
@@ -254,6 +260,8 @@ func main() {
 	flag.StringVar(&outdir, "out", "./puppets", "the output directory containing instantiated netsim peers")
 	var basePort int
 	flag.IntVar(&basePort, "port", 18888, "start of port range used for each running sbot")
+	var verbose bool
+	flag.BoolVar(&verbose, "v", false, "increase logging verbosity")
 	flag.Parse()
 	/*
 	 * the language implementation dir contains the code for starting a puppet, via a shim.
@@ -271,6 +279,6 @@ func main() {
 	resetPuppetDir(outdir)
 	sim := makeSimulator(basePort, outdir, flag.Args())
 	lines := readTest(testfile)
-	sim.ParseTest(lines)
+	sim.ParseTest(lines, verbose)
 	sim.execute()
 }

--- a/cmd/dsl/util.go
+++ b/cmd/dsl/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"path/filepath"
 	"strings"
 )
 
@@ -39,7 +40,11 @@ func parseTestLine(line string, id int) Instruction {
 }
 
 func readTest(filename string) []string {
-	testfile, err := ioutil.ReadFile(filename)
+	absfilename, err := filepath.Abs(filename)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	testfile, err := ioutil.ReadFile(absfilename)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
This PR removes the last hard-coded bits of the network simulator (which were there to get things up and running quickly, and figure out unknown problems :)

The cli takes flags to decide the initial port range (more sophisticated port mgmt logic will be coming), where the root directory containing all of the running sbot instances will live, and the test file to run. Each language implementation is passed as a flagless argument, after the flags.

Currently implemented flags:
```
Usage of ./dsl:
  -out string
    	the output directory containing instantiated netsim peers (default "./puppets")
  -port int
    	start of port range used for each running sbot (default 18888)
  -spec string
    	test file containing network simulator test instructions (default "./test.txt")
```

Example invocation:
```
./dsl  --port 20201 --out ./puppets --spec test.txt ~/code/netsim-experiments/ssb-server ~/code/go/src/go-ssb/cmd/go-sbot
```

Where
* the custom nodejs ssb-server is passed in as `~/code/netsim-experiments/ssb-server` 
* the go-ssb sbot is passed in as `~/code/go/src/go-ssb/cmd/go-sbot`
* both directories contain a `sim-shim.sh` which correctly sets the ports and directories for their respective servers

## Appendix
### go-ssb `sim-shim.sh`
```sh
#!/bin/bash
DIR="$1"
PORT="$2"
echo using port "$PORT" and "$(($PORT+100))"
echo puppet lives in "$DIR" 
LIBRARIAN_WRITEALL=0 /home/cblgh/code/go/src/go-ssb/cmd/go-sbot/go-sbot -lis :"$PORT" -wslis :"$(($PORT+100))" -repo "$DIR"
```

### ssb-server `sim-shim.sh`
```sh
#!/bin/bash
SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
PORT="$2"
WS_PORT=$(("$PORT"+100))
puppet_dir="$1"
echo "gossip port: $PORT"
echo "ws port: $WS_PORT"
echo "puppet lives in  $puppet_dir"

echo "starting as DEBUG=* "$SCRIPTPATH"/bin.js start -- --path "$puppet_dir" --port "$PORT" --ws.port "$WS_PORT""
echo "first, though: run a hack to generate the secret file.."
timeout 0.2 "$SCRIPTPATH"/bin.js start -- --path "$puppet_dir" --port "$PORT" --ws.port "$WS_PORT"
# ..so that we can make sure the secret has decent permissions (the go muxrpc-client complains otherwise)
chmod 600 "$puppet_dir/secret"
# finally: start the ssb-server with custom ports
DEBUG=* "$SCRIPTPATH"/bin.js start -- --path "$puppet_dir" --port "$PORT" --ws.port "$WS_PORT" 
``` 

### Network simulator test example
```
start alice ssb-server
start bob ssb-server
start carol go-sbot
post carol
post carol
follow carol alice
has carol carol@3
log carol 1
follow bob alice
wait 1000
isfollowing bob alice
isfollowing carol alice
isnotfollowing carol bob 
connect bob alice
wait 1000
has bob alice@latest
```

#### Output
```
## Start test file                                                                                                              
# 1 start alice ssb-server
# 2 start bob ssb-server
# 3 start carol go-sbot
# 4 post carol
# 5 post carol
# 6 follow carol alice
# 7 has carol carol@3
# 8 log carol 1
# 9 follow bob alice
# 10 wait 1000
# 11 isfollowing bob alice
# 12 isfollowing carol alice
# 13 isnotfollowing carol bob
# 14 connect bob alice
# 15 wait 1000
# 16 has bob alice@latest
## End test file
ok 1 - start alice ssb-server
# alice has id @em4PUP557LBWeFXOIOOj8Ym05tv/I+MUmRzNEqfHDqs=.ed25519
# logging to alice.txt
ok 2 - start bob ssb-server
# bob has id @Hfu+taa67yf/GY//NXiBWF0NLuUfPaGeSj9k5XTyWAg=.ed25519
# logging to bob.txt
ok 3 - start carol go-sbot
# carol has id @pbj5N9Xv2lynCaDrl4Byrb0+ZK6Ghkzj2TV0ZMwZ4JA=.ed25519
# logging to carol.txt
ok 4 - post carol
ok 5 - post carol
ok 6 - follow carol alice
ok 7 - has carol carol@3
ok 8 - log carol 1
# {
#  "author": "@pbj5N9Xv2lynCaDrl4Byrb0+ZK6Ghkzj2TV0ZMwZ4JA=.ed25519",
#  "content": {
#   "blocking": false,
#   "contact": "@em4PUP557LBWeFXOIOOj8Ym05tv/I+MUmRzNEqfHDqs=.ed25519",
#   "following": true,
#   "type": "contact"
#  },
#  "hash": "sha256",
#  "previous": "%JvHmUNyaYUybZaoOwg/fVJUueZ2sIvs11Q04Hm/TTK0=.sha256",
#  "sequence": 3,
#  "signature": "pEK6AHQwKapf3zoXWJ4HpDScJ1XBNkNgcd8yH9BUdYM6d94d12BbYvKevoqVrWUeYPwR80VLRuMZNS3at8SiCg==.sig.ed25519",
#  "timestamp": 1622133070833
# }
ok 9 - follow bob alice
ok 10 - wait 1000
ok 11 - isfollowing bob alice
ok 12 - isfollowing carol alice
ok 13 - isnotfollowing carol bob
ok 14 - connect bob alice
ok 15 - wait 1000
ok 16 - has bob alice@latest
1..16
```