### PR TITLE
Implement process killing for peers during & after simulation

### DIFF
--- a/cmd/dsl/instruction.go
+++ b/cmd/dsl/instruction.go
@@ -24,6 +24,10 @@ func (instr Instruction) TestFailure(err error) {
 	taplog(err.Error())
 }
 
+func (instr Instruction) TestAbort(err error) {
+	fmt.Printf("Bail out! %s (%s)\n", err.Error(), instr.line)
+}
+
 func (instr Instruction) getSrc() string {
 	return instr.args[0]
 }

--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -366,13 +366,13 @@ func preparePuppetDir(dir string) string {
 	return absdir
 }
 
-func monitorInterrupts(sim Simulator) {
+func (s Simulator) monitorInterrupts() {
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		sig := <-c
 		taplog(fmt.Sprintf("received shutdown signal, shutting down (signal %s)\n", sig.String()))
-		sim.cancelExecution()
+		s.cancelExecution()
 	}()
 }
 
@@ -408,9 +408,8 @@ func main() {
 
 	outdir = preparePuppetDir(outdir)
 	sim := makeSimulator(basePort, outdir, flag.Args(), verbose)
-
 	// monitor system interrupts via cmd-c/mod-c
-	monitorInterrupts(sim)
+	sim.monitorInterrupts()
 
 	lines := readTest(testfile)
 	sim.ParseTest(lines)

--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -322,7 +322,9 @@ func (s Simulator) execute() {
 			err := DoHast(srcPuppet, dstPuppet, seq)
 			s.evaluateRun(err)
 		default:
-			instr.Print()
+			// unknown command, abort test run
+			instr.TestAbort(errors.New("Unknown simulator command"))
+			s.exit()
 		}
 	}
 
@@ -374,6 +376,12 @@ func monitorInterrupts(sim Simulator) {
 	}()
 }
 
+func (s Simulator) exit() {
+	taplog("Closing all puppets")
+	s.cancelExecution()
+	time.Sleep(1 * time.Second)
+}
+
 func main() {
 	var testfile string
 	flag.StringVar(&testfile, "spec", "./test.txt", "test file containing network simulator test instructions")
@@ -409,7 +417,5 @@ func main() {
 	sim.execute()
 
 	// once we are done we want all puppets to exit
-	taplog("Closing all puppets")
-	sim.cancelExecution()
-	time.Sleep(1 * time.Second)
+	sim.exit()
 }

--- a/cmd/dsl/util.go
+++ b/cmd/dsl/util.go
@@ -14,8 +14,8 @@ func trimFeedId(feedID string) string {
 }
 
 func multiserverAddr(p Puppet) string {
-	// format: net:192.168.88.18:18889~shs:xDPgE3tTTIwkt1po+2GktzdvwJLS37ZEd+TZzIs66UU=
-	ip := "192.168.88.18"
+	// format: net:localhost:18889~shs:xDPgE3tTTIwkt1po+2GktzdvwJLS37ZEd+TZzIs66UU=
+	ip := "localhost"
 	return fmt.Sprintf("net:%s:%d~shs:%s", ip, p.Port, trimFeedId(p.feedID))
 }
 

--- a/commands.md
+++ b/commands.md
@@ -1,0 +1,51 @@
+# Network Simulator Test Commands
+As described in the [initial syntax proposal](./domain-specific-language.md), the network
+simulator works by executing a test specification file. The current set of implemented commands
+can be read below.
+
+### Command Parameter Legend
+The listing below provides brief explanations of the various parameters that are provided to
+the network simulator commands when writing test files.
+
+* `<name>` is non-spaced name used to refer to the same test puppet (i.e. an ssb identity),
+* `<seqno>` is a sequence number as derived from the log of a particular peer e.g. 1, 2, 5, 1337
+    * the keyword `<name>@latest` is implemented as a shorthand for referring to the latest
+      sequence number according to the identity whose log it is.
+* `<implementation-folder>` is defined as the last folder name of the path passed to the
+  network simulator on startup. Since many implementations may be passed and used during a
+  single simulation, they are provided as flagless arguments **after** any command-line flags.
+  Example: `netsim -out ~/netsim-tests ~/code/ssb-server-19 ~/code/ssb-server-new ~/code/go-ssb-sbot`
+    * the -out flag defines the output directory for logs and generated identities (`~/netsim-tests` in this case)
+    * `~/code/ssb-server-19` would be referenced as `ssb-server-19` in the test specification
+      as e.g. `start alice ssb-server-19`
+
+## Implemented Commands
+```
+start <name> <implementation-folder>
+stop <name>
+wait <milliseconds>
+has <name1> <name2>@<latest||seqno>
+post <name>
+follow <name1> <name2>
+unfollow <name1> <name2>
+isfollowing <name1> <name2>
+isnotfollowing <name1> <name2>
+connect <name1> <name2>
+disconnect <name1> <name2>
+```
+
+## Not yet implemented
+The following commands might, or might not, be implemented—or they might be implemented with another name.
+
+```
+block <name1> <name2>
+isblocked <name1> <name2>
+isnotblocked <name1> <name2>
+hasnot <name1> <name2>@<latest||seqno>
+// the following commands are to be used in combination with a fixtures folder, passed with the flag --fixtures <folder>
+setup <name> @<base64>.ed25519 <global truncate count>
+truncate <name1> <name2>@<new length>
+```
+
+The commands `setup` and `truncate` would be introduced if the simulator implements
+support for loading in [ssb-fixtures](https://github.com/ssb-ngi-pointer/ssb-fixtures) pre-generated offset files.

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/ssb-ngi-pointer/netsim
 go 1.16
 
 require (
-	go.cryptoscope.co/muxrpc/v2 v2.0.6 // indirect
-	go.cryptoscope.co/netwrap v0.1.0 // indirect
-	go.cryptoscope.co/nocomment v0.0.0-20210520094614-fb744e81f810 // indirect
-	go.cryptoscope.co/secretstream v1.2.3 // indirect
-	go.mindeco.de/ssb-refs v0.2.0 // indirect
+	go.cryptoscope.co/muxrpc/v2 v2.0.6
+	go.cryptoscope.co/netwrap v0.1.0
+	go.cryptoscope.co/nocomment v0.0.0-20210520094614-fb744e81f810
+	go.cryptoscope.co/secretstream v1.2.3
+	go.mindeco.de/ssb-refs v0.2.0
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 // We need our internal/extra25519 since agl pulled his repo recently.

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
This PR implements:
* support for gracefully stopping the running test with ctrl-c
* a stop command `stop <name>`
* processes started by the simulator are now killed after exiting :')
* TAP's `Bail out!` state, for handling catastrophic failures (e.g. trying to run a command that doesn't exist)

Also added:
* documentation of the currently implemented commands (see commands.md)