### PR TITLE
add -hops, -caps flags. set ,  env variables

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -11,16 +11,14 @@ import (
 	"go.cryptoscope.co/secretstream"
 )
 
-const defaultShsCap = "1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s="
-
-func NewTCP(port int, secretPath string) (muxrpc.Endpoint, error) {
+func NewTCP(port int, capsKey, secretPath string) (muxrpc.Endpoint, error) {
 	kp, err := keys.LoadKeyPair(secretPath)
 	if err != nil {
 		return nil, err
 	}
 
 	// default app key for the secret-handshake connection
-	appkey, err := base64.StdEncoding.DecodeString(defaultShsCap)
+	appkey, err := base64.StdEncoding.DecodeString(capsKey)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/dsl/commands.go
+++ b/cmd/dsl/commands.go
@@ -16,7 +16,7 @@ import (
 )
 
 func asyncRequest(p Puppet, method muxrpc.Method, payload, response interface{}) error {
-	c, err := client.NewTCP(p.Port, fmt.Sprintf("%s/secret", p.directory))
+	c, err := client.NewTCP(p.Port, p.caps, fmt.Sprintf("%s/secret", p.directory))
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func asyncRequest(p Puppet, method muxrpc.Method, payload, response interface{})
 }
 
 func sourceRequest(p Puppet, method muxrpc.Method, opts interface{}) (muxrpc.Endpoint, *muxrpc.ByteSource, error) {
-	c, err := client.NewTCP(p.Port, fmt.Sprintf("%s/secret", p.directory))
+	c, err := client.NewTCP(p.Port, p.caps, fmt.Sprintf("%s/secret", p.directory))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/commands.md
+++ b/commands.md
@@ -42,6 +42,10 @@ block <name1> <name2>
 isblocked <name1> <name2>
 isnotblocked <name1> <name2>
 hasnot <name1> <name2>@<latest||seqno>
+// advanced per-puppet settings; 
+// introduces side effects when e.g. stopping then starting a puppet again
+hops <name> <number>    // should be called before starting a peer to have any effect
+caps <name> <string>    // should be called before starting a peer to have any effect
 // the following commands are to be used in combination with a fixtures folder, passed with the flag --fixtures <folder>
 setup <name> @<base64>.ed25519 <global truncate count>
 truncate <name1> <name2>@<new length>


### PR DESCRIPTION
This implements basic support for changing the caps & hops used for all peers in the simulation. 

Per peer settings may come later, but implementing them causes state to be taken care of in a way that is not currently needed. So taking it easy with the `hops <name> <number>` and `caps <name> <string>` commands until it is obvious that they are needed :)

## Appendix
See the following sim-shim's for how the caps & hops are used for ssb-server & go-sbot.

### js `sim-shim.sh`
```bash
#!/usr/bin/env bash
echo "caps is set to ${CAPS}"
echo "hops is set to ${HOPS}"
SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
PORT="$2"
WS_PORT=$(("$PORT"+1))
puppet_dir="$1"
echo "gossip port: $PORT"
echo "ws port: $WS_PORT"
echo "puppet lives in  $puppet_dir"

echo 'starting as DEBUG=* exec "$SCRIPTPATH"/bin.js start -- --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$puppet_dir" --port "$PORT" --ws.port "$WS_PORT"'
echo "first, though: run a hack to generate the secret file.."
timeout 0.2 "$SCRIPTPATH"/bin.js start -- --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$puppet_dir" --port "$PORT" --ws.port "$WS_PORT"
# ..so that we can make sure the secret has decent permissions (the go muxrpc-client complains otherwise)
chmod 600 "$puppet_dir/secret"
# finally: start the ssb-server with custom ports
DEBUG=* exec "$SCRIPTPATH"/bin.js start -- --friends.hops "$HOPS" --caps.shs "$CAPS" --path "$puppet_dir" --port "$PORT" --ws.port "$WS_PORT"
```

### go `sim-shim.sh`
```bash
#!/usr/bin/env bash
DIR="$1"
PORT="$2"
echo "using ports ${PORT} and $(($PORT+1))"
echo "using caps ${CAPS} and hops ${HOPS}"
echo "puppet lives in ${DIR}"
export LIBRARIAN_WRITEALL=0 
exec /home/cblgh/code/go/src/go-ssb/cmd/go-sbot/go-sbot -lis :"$PORT" -wslis :"$(($PORT+1))" -repo "$DIR" -shscap "${CAPS}" -hops "${HOPS}"
```