### PR TITLE
implement enter, hops, and caps puppet commands

### DIFF
--- a/cmd/dsl/main.go
+++ b/cmd/dsl/main.go
@@ -274,6 +274,7 @@ func (s Simulator) execute() {
 			p.usesFixtures = true
 			p.feedID = id
 			s.puppetMap[name] = p
+			instr.TestSuccess()
 		case "hops":
 			name := instr.args[0]
 			hops, err := strconv.Atoi(instr.args[1])

--- a/commands.md
+++ b/commands.md
@@ -21,6 +21,9 @@ the network simulator commands when writing test files.
 
 ## Implemented Commands
 ```
+enter <name>            // should be called before any other command dealing with the named peer
+hops <name> <number>    // should be called before starting a peer to have any effect
+caps <name> <string>    // should be called before starting a peer to have any effect
 start <name> <implementation-folder>
 stop <name>
 wait <milliseconds>
@@ -42,14 +45,10 @@ block <name1> <name2>
 isblocked <name1> <name2>
 isnotblocked <name1> <name2>
 hasnot <name1> <name2>@<latest||seqno>
-// advanced per-puppet settings; 
-// introduces side effects when e.g. stopping then starting a puppet again
-hops <name> <number>    // should be called before starting a peer to have any effect
-caps <name> <string>    // should be called before starting a peer to have any effect
 // the following commands are to be used in combination with a fixtures folder, passed with the flag --fixtures <folder>
-setup <name> @<base64>.ed25519 <global truncate count>
+load <name> @<base64>.ed25519
 truncate <name1> <name2>@<new length>
 ```
 
-The commands `setup` and `truncate` would be introduced if the simulator implements
+The commands `load` and `truncate` would be introduced if the simulator implements
 support for loading in [ssb-fixtures](https://github.com/ssb-ngi-pointer/ssb-fixtures) pre-generated offset files.

--- a/commands.md
+++ b/commands.md
@@ -24,6 +24,7 @@ the network simulator commands when writing test files.
 enter <name>            // should be called before any other command dealing with the named peer
 hops <name> <number>    // should be called before starting a peer to have any effect
 caps <name> <string>    // should be called before starting a peer to have any effect
+load <name> @<base64>.ed25519
 start <name> <implementation-folder>
 stop <name>
 wait <milliseconds>
@@ -46,7 +47,6 @@ isblocked <name1> <name2>
 isnotblocked <name1> <name2>
 hasnot <name1> <name2>@<latest||seqno>
 // the following commands are to be used in combination with a fixtures folder, passed with the flag --fixtures <folder>
-load <name> @<base64>.ed25519
 truncate <name1> <name2>@<new length>
 ```
 


### PR DESCRIPTION
This PR adds the `enter`, `load`, `hops` and `caps` commands. It also adds basic fixtures loading via the optional `--fixtures <path>` flag.

* `enter <name>` declare a name that will be referenced in the test. It must be called before that name is referenced elsewhere in the test
* `load <name> @<pubkey>.ed25519` load an identity from the `--fixtures` provided fixtures. Simulation aborts if `--fixtures` omitted.
* `hops <name> <number>` sets the hops setting on the specified puppet
* `caps <name> <string>` sets the hops setting on the specified puppet