### PR TITLE
Fix test generation, and the print follow graph util

### DIFF
--- a/cmd/netsim/main.go
+++ b/cmd/netsim/main.go
@@ -39,11 +39,13 @@ func main() {
 		var ssbServer string
 		var focusedPuppets int
 		var onlySplice bool
+		var generationSeed int64
 		flag.BoolVar(&onlySplice, "no-test-script", false, "only converts the input fixtures to netsim-style fixtures")
 		flag.BoolVar(&replicateBlocked, "replicate-blocked", false, "if flag is present, blocked peers will be replicated")
 		flag.StringVar(&outpath, "out", "./", "the output path of the generated netsim test & its auxiliary files")
 		flag.StringVar(&ssbServer, "sbot", "ssb-server", "the ssb server to start puppets with")
 		flag.IntVar(&focusedPuppets, "focused", 2, "number of puppets that verify they are fully replicating their hops")
+		flag.Int64Var(&generationSeed, "seed", 0, "seed used by test generation")
 		flag.Parse()
 
 		if len(flag.Args()) == 0 {
@@ -62,7 +64,7 @@ func main() {
 		// use the spliced logs to generate expectations
 		expectations := generateExpectations(fixturesOutput, hops, replicateBlocked)
 		// use the generated expectations & generate the test
-		generatedTest := generateTest(fixturesOutput, ssbServer, focusedPuppets, hops, expectations)
+		generatedTest := generateTest(fixturesOutput, ssbServer, focusedPuppets, hops, generationSeed, expectations)
 		// echo
 		fmt.Println(generatedTest)
 		// save test file to disk
@@ -119,11 +121,12 @@ func printHelp(cmd, usage, description string) {
 	os.Exit(1)
 }
 
-func generateTest(fixturesRoot, sbot string, focused, hops int, expectations map[string][]string) string {
+func generateTest(fixturesRoot, sbot string, focused, hops int, seed int64, expectations map[string][]string) string {
 	var generationArgs generation.Args
 	generationArgs.FixturesRoot = fixturesRoot
 	generationArgs.SSBServer = sbot
 	generationArgs.MaxHops = hops
+	generationArgs.Seed = seed
 	generationArgs.FocusedCount = focused
 
 	s := new(strings.Builder)

--- a/cmd/print-follow-graph/print-follow-graph.go
+++ b/cmd/print-follow-graph/print-follow-graph.go
@@ -21,10 +21,17 @@ func check(err error) {
 
 func main() {
 	var args generation.Args
-	flag.StringVar(&args.FixturesRoot, "fixtures", "./fixtures-output", "root folder containing spliced out ssb-fixtures")
 	flag.IntVar(&args.MaxHops, "hops", 2, "the max hops count to use")
 	flag.IntVar(&args.FocusedCount, "focused", 2, "number of puppets to use for focus group (i.e. # of puppets that verify they are replicating others)")
 	flag.Parse()
+	if len(flag.Args()) == 0 {
+		fmt.Printf("print-follow-graph <options> path-to-spliced-fixtures\n")
+		fmt.Println("prints the follow graph described by a spliced out fixtures folder (netsim generate output), and its replication expectations")
+		fmt.Println("Options:")
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+	args.FixturesRoot = flag.Args()[0]
 
 	var err error
 	g := generation.Generator{Args: args, Output: os.Stdout}
@@ -38,13 +45,15 @@ func main() {
 
 	puppetNames := make([]string, 0, len(g.IDsToNames))
 	g.NamesToIDs = make(map[string]string)
+	// map puppet names to their ids with g.NamesToIDs
 	for id, secretFolder := range g.IDsToNames {
 		g.NamesToIDs[secretFolder] = id
 		puppetNames = append(puppetNames, g.IDsToNames[id])
 	}
 	sort.Strings(puppetNames)
 
-	// the cohort of peers we care about; the ones who will be issuing `has` stmts, the ones whose data we will inspect
+	// g.FocusGroup is the cohort of peers we care about; the ones who will be issuing `has` stmts, the ones whose data we
+	// will inspect
 	g.FocusGroup = make([]string, args.FocusedCount)
 	for i := 0; i < args.FocusedCount; i++ {
 		g.FocusGroup[i] = fmt.Sprintf("puppet-%05d", i)
@@ -61,10 +70,10 @@ func main() {
 
 			 ========================
 			  start start start start
-			v hops 3 connect hops 2 v
-			v hops 2 connect hops 1 v
-			v hops 1 connect focus  v
-			  done done  done done
+			v hops 3 > connect > hops 2 v
+			v hops 2 > connect > hops 1 v
+			v hops 1 > connect > focus  v
+			  done done done done done
 			 ========================
 	*/
 	focusIds := g.GetIDs(g.FocusGroup)

--- a/cmd/print-follow-graph/print-follow-graph.go
+++ b/cmd/print-follow-graph/print-follow-graph.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ssb-ngi-pointer/netsim/generation"
 	"log"
 	"math/rand"
+	"os"
 	"path"
 	"sort"
 )
@@ -26,7 +27,7 @@ func main() {
 	flag.Parse()
 
 	var err error
-	g := generation.Generator{Args: args}
+	g := generation.Generator{Args: args, Output: os.Stdout}
 	// map of id -> [list of followed ids]
 	var followMap map[string][]string
 	followMap, _, err = generation.GetFollowMap(path.Join(args.FixturesRoot, "follow-graph.json"))

--- a/generation/generate-test.go
+++ b/generation/generate-test.go
@@ -14,11 +14,10 @@ import (
 )
 
 type Args struct {
-	SSBServer        string
-	FixturesRoot     string
-	ExpectationsPath string
-	FocusedCount     int
-	MaxHops          int
+	SSBServer    string
+	FixturesRoot string
+	FocusedCount int
+	MaxHops      int
 }
 
 type Generator struct {
@@ -300,14 +299,18 @@ func (g Graph) RecurseFollows(id string, hopsLeft int, verbose bool) []Pair {
 		return []Pair{}
 	}
 	var pairs []Pair
+	// from the pov of `id`: discover all new, direct follows `otherId`
 	for _, otherId := range g.FollowMap[id] {
+		// other was already known, continue search for the new in next iteration
 		if g.Seen[otherId] {
 			continue
 		}
+		// print out the newly discovered node and where it is in the hops graph
 		if verbose {
+			// a direct hop from our initial starting point
 			if hopsLeft == g.Gen.Args.MaxHops {
 				fmt.Fprintf(g.Gen.Output, "%d %s\n", g.Gen.Args.MaxHops-hopsLeft+1, g.Gen.IDsToNames[otherId])
-			} else {
+			} else { // an indirect hop, make a note of which node followed the other
 				fmt.Fprintf(g.Gen.Output, "%d %s (via %s)\n", g.Gen.Args.MaxHops-hopsLeft+1, g.Gen.IDsToNames[otherId], g.Gen.IDsToNames[id])
 			}
 		}

--- a/generation/generate-test.go
+++ b/generation/generate-test.go
@@ -213,8 +213,21 @@ func GenerateTest(args Args, expectations map[string][]string, outputWriter io.W
 	for _, pair := range hopsPairs {
 		g.batchConnect(pair)
 	}
-	// issue another round of connections to be sure we have flooded the network & receive all data from the hops
-	// (short-circuits a scheduling problem by paying with more execution time)
+	// issue another round of connections to be sure we have flooded the network & receive all data from the hops.
+	// short-circuits a scheduling problem by paying with more execution time.
+	//
+	// the problem:
+	// we order the connection statements so that the outermost hops are connected to their followers, and so on until
+	// the focused peers connect to their direct follows. the purpose is to trickle down data along the follows & hops and
+	// into the focused peers, whose local db we inspect using expectations & `has` statements.
+	//
+	// in some cases, however, the focused peers will not get an indirect follow's data due to the order connection
+	// statements can happen. to solve this, we perform two rounds and are ensured that all data should flow along the
+	// hops correctly.
+	//
+	// the primary reason this happens is because in netsim's spliced out fixtures, each peer initially only holds their
+	// own data. when they connect with others, the connecting peer gets the data the other has as well (the peer's own
+	// messages, and messages from their previously-connected-with follows)
 	for _, pair := range hopsPairs {
 		g.batchConnect(pair)
 	}

--- a/generation/generate-test.go
+++ b/generation/generate-test.go
@@ -30,7 +30,7 @@ type Generator struct {
 	isBlocking         map[string]map[string]bool
 	Args               Args
 
-	output io.Writer
+	Output io.Writer
 }
 
 func check(err error) {
@@ -138,7 +138,7 @@ func GenerateTest(args Args, expectations map[string][]string, outputWriter io.W
 	g := Generator{
 		Args:               args,
 		currentlyExecuting: make(map[string]bool),
-		output:             outputWriter,
+		Output:             outputWriter,
 	}
 
 	var err error
@@ -198,8 +198,8 @@ func GenerateTest(args Args, expectations map[string][]string, outputWriter io.W
 	// output `enter`, `load` stmts, sorted by puppet name
 	for _, puppetName := range puppetNames {
 		puppetId := g.NamesToIDs[puppetName]
-		fmt.Fprintf(g.output, "enter %s\n", puppetName)
-		fmt.Fprintf(g.output, "load %s %s\n", puppetName, puppetId)
+		fmt.Fprintf(g.Output, "enter %s\n", puppetName)
+		fmt.Fprintf(g.Output, "load %s %s\n", puppetName, puppetId)
 	}
 
 	// start the focus group
@@ -236,26 +236,26 @@ func (g Generator) batchConnect(p Pair) {
 
 func (g Generator) has(issuer string, names []string) {
 	for _, name := range names {
-		fmt.Fprintf(g.output, "has %s %s@latest\n", issuer, name)
+		fmt.Fprintf(g.Output, "has %s %s@latest\n", issuer, name)
 	}
 }
 
 func (g Generator) disconnect(issuer string, names []string) {
 	for _, name := range names {
-		fmt.Fprintf(g.output, "disconnect %s %s\n", issuer, name)
+		fmt.Fprintf(g.Output, "disconnect %s %s\n", issuer, name)
 	}
 }
 
 func (g Generator) connect(issuer string, names []string) {
 	for _, name := range names {
-		fmt.Fprintf(g.output, "connect %s %s\n", issuer, name)
+		fmt.Fprintf(g.Output, "connect %s %s\n", issuer, name)
 	}
 }
 
 func (g Generator) start(names []string) {
 	for _, name := range names {
 		if _, exists := g.currentlyExecuting[name]; !exists {
-			fmt.Fprintf(g.output, "start %s %s\n", name, g.Args.SSBServer)
+			fmt.Fprintf(g.Output, "start %s %s\n", name, g.Args.SSBServer)
 			g.currentlyExecuting[name] = true
 		}
 	}
@@ -275,7 +275,7 @@ func (g Generator) stop(names []string) {
 		}
 		if _, exists := g.currentlyExecuting[name]; exists {
 			delete(g.currentlyExecuting, name)
-			fmt.Fprintf(g.output, "stop %s\n", name)
+			fmt.Fprintf(g.Output, "stop %s\n", name)
 		}
 	}
 }
@@ -306,9 +306,9 @@ func (g Graph) RecurseFollows(id string, hopsLeft int, verbose bool) []Pair {
 		}
 		if verbose {
 			if hopsLeft == g.Gen.Args.MaxHops {
-				fmt.Fprintf(g.Gen.output, "%d %s\n", g.Gen.Args.MaxHops-hopsLeft+1, g.Gen.IDsToNames[otherId])
+				fmt.Fprintf(g.Gen.Output, "%d %s\n", g.Gen.Args.MaxHops-hopsLeft+1, g.Gen.IDsToNames[otherId])
 			} else {
-				fmt.Fprintf(g.Gen.output, "%d %s (via %s)\n", g.Gen.Args.MaxHops-hopsLeft+1, g.Gen.IDsToNames[otherId], g.Gen.IDsToNames[id])
+				fmt.Fprintf(g.Gen.Output, "%d %s (via %s)\n", g.Gen.Args.MaxHops-hopsLeft+1, g.Gen.IDsToNames[otherId], g.Gen.IDsToNames[id])
 			}
 		}
 		pairs = append(pairs, Pair{src: id, dst: otherId})
@@ -324,10 +324,10 @@ func (g Graph) RecurseFollows(id string, hopsLeft int, verbose bool) []Pair {
 
 func (g Generator) waitUntil(issuer string, names []string) {
 	for _, name := range names {
-		fmt.Fprintf(g.output, "waituntil %s %s@latest\n", issuer, name)
+		fmt.Fprintf(g.Output, "waituntil %s %s@latest\n", issuer, name)
 	}
 }
 
 func (g Generator) waitMs(ms int) {
-	fmt.Fprintf(g.output, "wait %d\n", ms)
+	fmt.Fprintf(g.Output, "wait %d\n", ms)
 }


### PR DESCRIPTION
* fixed crash in print-follow-graph (didn't catch this breaking in the transition from using strings to `io.Writer` :)
* fixed bug in generation wrt printing correct hops relations when used with `Verbose: true`
* connections are now issued in two rounds instead of one; a monkey patched solution for a scheduling problem that arose in one consistently failing assertion of the generated netsim test
* added a `--seed` parameter to `netsim generate` and `generate-test`, which changes the connection order of puppets in the generated test