### PR TITLE
add final timer stats, sort by starting order

### DIFF
--- a/sim/dsl.go
+++ b/sim/dsl.go
@@ -642,6 +642,21 @@ func (s Simulator) logMetrics() {
 		count := strconv.Itoa(puppet.totalMessages)
 		taplog(fmt.Sprintf(fmtString, puppet.name, total, active, count))
 	}
+	// print timers if applicable
+	if len(s.timers) > 0 {
+		taplog("\nStarted timers & final elapsed time")
+		fmtString = "%-12s %12s"
+		taplog(fmt.Sprintf(fmtString, "Label", "Time"))
+		var labels []string
+		for label := range s.timers {
+			labels = append(labels, label)
+		}
+		sort.Strings(labels)
+		for _, label := range labels {
+			timer := s.timers[label]
+			taplog(fmt.Sprintf(fmtString, label, timer.elapsed.Truncate(time.Millisecond)))
+		}
+	}
 }
 
 func (s Simulator) exit() {


### PR DESCRIPTION
for a netsim test that looks like:

```
timerstart all 
enter pupper
# here's a dang comment
timerstart generic
start pupper ssb-server
wait 400 
timerstop generic
timerstop all 
```


we now generate a final printout that looks like the following (and includes the timer stats added in this pr :~)
```tap
1..8
# End of simulation
# Total time: 2.478605191s
# Active time: 78.605191ms
# Puppet count: 1
# Puppet         Total time  Active time   # messages
# pupper             2.476s         76ms            0
# 
# Started timers & final elapsed time
# Label                Time
# all                2.478s
# generic            2.478s
# Closing all puppets
```