### PR TITLE
queryLatest: replicate.upto -> createLogStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,12 @@ Currently, the following calls are required to be implemented before an ssb impl
 testable in netsim:
 
 **Essential**
+* `createLogStream` 
 * `createHistoryStream`
 * `whoami`
 * `publish`
-* `replicate.upto`
 * `conn.connect`
 * `conn.disconnect`
 
 **Extras**
-* `createLogStream` used by the `log` command
 * `friends.isFollowing` used by `isfollowing` / `isnotfollowing`


### PR DESCRIPTION
Replace use of replicate.upto as `ssb-db2` does not appear to respond
properly to requests using that muxrpc. Instead, use `createLogStream`
to achieve the same thing albeit at the expense of some performance.

Also implemented is a small heuristic to ensure that the javascript & go
implementations (which have slightly different responses when answering
a createLogStream call) all work.