### PR TITLE
add reset peer server-impl, resets execution folder to initial state

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,6 +28,7 @@ skipoffset <name>       // should be called before starting a peer to have any e
 alloffsets <name>       // should be called before starting a peer to have any effect (preloads the non-spliced input ssb-fixtures => puppet acts like a pub)
 load <name> @<base64>.ed25519               // loads an id & its associated secret + log.offset from fixtures
 start <name> <implementation-folder>        // spin up name as ssb peer using the specifed sbot implementation
+reset <name> <implementation-folder>        // resets a peer's execution folder -> they will have forgotten any messages they synced from others
 stop <name>                                 // stop a currently running peer
 log <name> <amount of messages from the end to debug print>
 wait <milliseconds>                         // pause script execution

--- a/sim/dsl.go
+++ b/sim/dsl.go
@@ -396,7 +396,7 @@ func (s Simulator) execute() {
 				return
 			}
 			instr.TestSuccess()
-			taplog(fmt.Sprintf("removed %s", p.name, subfolder))
+			taplog(fmt.Sprintf("removed %s", subfolder))
 		case "start":
 			name := s.getInstructionArg(1)
 			langImpl := s.getInstructionArg(2)

--- a/sim/dsl.go
+++ b/sim/dsl.go
@@ -366,6 +366,37 @@ func (s Simulator) execute() {
 			p := s.getPuppet(name)
 			p.caps = caps
 			instr.TestSuccess()
+		case "reset":
+			name := s.getInstructionArg(1)
+			langImpl := s.getInstructionArg(2)
+			if _, ok := s.implementations[langImpl]; !ok {
+				err := errors.New(fmt.Sprintf("no such language implementation passed to simulator on startup (%s)", langImpl))
+				s.Abort(err)
+				return
+			}
+			p := s.getPuppet(name)
+			// puppet directory was empty => it was never started
+			if p.directory == "" {
+				instr.TestSuccess()
+				taplog(fmt.Sprintf("there was no execution folder to reset for %s", p.name))
+				continue
+			}
+			subfolder := fmt.Sprintf("%s-%s", langImpl, name)
+			fullpath := filepath.Join(s.puppetDir, subfolder)
+
+			absdir, err := filepath.Abs(fullpath)
+			if err != nil {
+				s.Abort(fmt.Errorf("%s errored during reset (%w)", p.name, err))
+				return
+			}
+			// remove the created puppet dir, thus resetting its starting state
+			err = os.RemoveAll(absdir)
+			if err != nil {
+				s.Abort(fmt.Errorf("%s errored during reset (%w)", p.name, err))
+				return
+			}
+			instr.TestSuccess()
+			taplog(fmt.Sprintf("removed %s", p.name, subfolder))
 		case "start":
 			name := s.getInstructionArg(1)
 			langImpl := s.getInstructionArg(2)


### PR DESCRIPTION
this command was added as it was needed for a particularly tricky benchmark that @mycognosist and @arj03 were generating.

in netsim, the first time you start a peer a folder will be created for the combination of `peer + ssb-implementation`, holding that peer's secret & synced messages. if you stop and then restart that peer, then it would start off from where it was previously.

`reset <peer> <implementation>` lets you wipe the peer's execution folder for a given implementation, which can be useful for certain kinds of tests. 

**note:** the secret will be wiped, so this is best used in combination with the `--fixtures <fixtures>`  flag (which sources a secret from an already generated dataset)